### PR TITLE
Bugfix spurious crypt() warning in log

### DIFF
--- a/pam_mysql.c
+++ b/pam_mysql.c
@@ -2872,9 +2872,12 @@ static pam_mysql_err_t pam_mysql_check_passwd(pam_mysql_ctx_t *ctx,
 
 				/* ENCRYPT */
 				case 1:
-					vresult = strcmp(row[0], crypt(passwd, row[0]));
-					if (errno) {
+					char *crypted_password = crypt(passwd, row[0]);
+					if (crypted_password == NULL) {
 						syslog(LOG_AUTHPRIV | LOG_ERR, PAM_MYSQL_LOG_PREFIX "something went wrong when invoking crypt() - %s", strerror(errno));
+						vresult = 1; // fail
+					} else {
+						vresult = strcmp(row[0], crypted_password);
 					}
 					break;
 


### PR DESCRIPTION
The crypt() function returns NULL on error, or the string otherwise.
Only in the case of an error (i.e. NULL return) is the value of errno
useful.

On my system, crypt() works as expected, but errno is set to ENOENT,
because the last system call that was executed tried to open
'/proc/sys/crypto/fips_enabled', which does not exist on my system.
However, crypt() works fine without that file, but doesn't reset errno
to 0.

This patch fixes that behaviour, by explicitly checking for a NULL
return value, and only then examining errno.

It also works around undefined behaviour (strcmp with a NULL argument),
and makes sure that the password is considered NOT to match if crypt()
fails.
